### PR TITLE
CRAN update to v3.7.5

### DIFF
--- a/R/R.cpp
+++ b/R/R.cpp
@@ -37,7 +37,7 @@ accumLine(SEXP line)
   if (STRING_ELT(line, 0) != NA_STRING) {
     str_in = CHAR(STRING_ELT(line, 0));
     if (R::singleton().AccumulateLine(str_in) != VR_OK) {
-      error(R::singleton().GetErrorString());
+      error("%s", R::singleton().GetErrorString());
     }
   }
 
@@ -61,7 +61,7 @@ accumLineLst(SEXP line)
     if (STRING_ELT(line, i) != NA_STRING) {
       str_in = CHAR(STRING_ELT(line, 0));
       if (R::singleton().AccumulateLine(str_in) != VR_OK) {
-        error(R::singleton().GetErrorString());
+        error("%s", R::singleton().GetErrorString());
       }
     }
   }
@@ -733,7 +733,7 @@ loadDB(SEXP filename)
   name = CHAR(STRING_ELT(filename, 0));
 
   if (R::singleton().LoadDatabase(name) != VR_OK) {
-    error(R::singleton().GetErrorString());
+    error("%s", R::singleton().GetErrorString());
   }
 
   return(R_NilValue);
@@ -759,7 +759,7 @@ loadDBLst(SEXP input)
   if (R::singleton().LoadDatabaseString((*poss).str().c_str()) != VR_OK) {
     // all dtors must be called before error
     delete poss;
-    error(R::singleton().GetErrorString());
+    error("%s", R::singleton().GetErrorString());
   }
 
   delete poss;
@@ -779,7 +779,7 @@ loadDBStr(SEXP input)
   string = CHAR(STRING_ELT(input, 0));
 
   if (R::singleton().LoadDatabaseString(string) != VR_OK) {
-    error(R::singleton().GetErrorString());
+    error("%s", R::singleton().GetErrorString());
   }
 
   return(R_NilValue);
@@ -789,7 +789,7 @@ SEXP
 runAccum(void)
 {
   if (R::singleton().RunAccumulated() != VR_OK) {
-    error(R::singleton().GetErrorString());
+    error("%s", R::singleton().GetErrorString());
   }
   return(R_NilValue);
 }
@@ -806,7 +806,7 @@ runFile(SEXP filename)
 
   name = CHAR(STRING_ELT(filename, 0));
   if (R::singleton().RunFile(name) != VR_OK) {
-    error(R::singleton().GetErrorString());
+    error("%s", R::singleton().GetErrorString());
   }
 
   return(R_NilValue);
@@ -824,7 +824,7 @@ runString(SEXP input)
 
   in = CHAR(STRING_ELT(input, 0));
   if (R::singleton().RunString(in) != VR_OK) {
-    error(R::singleton().GetErrorString());
+    error("%s", R::singleton().GetErrorString());
   }
 
   return(R_NilValue);
@@ -849,7 +849,7 @@ runStringLst(SEXP input)
 
   if (R::singleton().RunString((*poss).str().c_str()) != VR_OK) {
     delete poss;
-    error(R::singleton().GetErrorString());
+    error("%s", R::singleton().GetErrorString());
   }
 
   delete poss;

--- a/R/phrGetErrorStrings.valgrind-leak.R.in
+++ b/R/phrGetErrorStrings.valgrind-leak.R.in
@@ -840,7 +840,7 @@ function(nuser, value) {
 ##' \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @usage phreeqc.dat  # phrLoadDatabaseString(phreeqc.dat)
 ##' @keywords dataset 
@@ -855,7 +855,7 @@ NULL
 ##' \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @usage ex15.dat  # phrLoadDatabaseString(ex15.dat)
 ##' @keywords dataset 
@@ -871,7 +871,7 @@ NULL
 ##' reformatted for use by \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @usage Amm.dat  # phrLoadDatabaseString(Amm.dat)
 ##' @keywords dataset 
@@ -885,7 +885,7 @@ NULL
 ##' has been reformatted for use by \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @usage wateq4f.dat  # phrLoadDatabaseString(wateq4f.dat)
 ##' @keywords dataset 
@@ -901,7 +901,7 @@ NULL
 ##' for use by \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @usage llnl.dat  # phrLoadDatabaseString(llnl.dat)
 ##' @keywords dataset 
 NULL
@@ -915,7 +915,7 @@ NULL
 ##' \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @usage minteq.dat  # phrLoadDatabaseString(minteq.dat)
 ##' @keywords dataset 
@@ -930,7 +930,7 @@ NULL
 ##' \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @usage minteq.v4.dat  # phrLoadDatabaseString(minteq.v4.dat)
 ##' @keywords dataset 
@@ -945,7 +945,7 @@ NULL
 ##' use by \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @usage pitzer  # phrLoadDatabaseString(pitzer.dat)
 ##' @keywords dataset 
@@ -961,7 +961,7 @@ NULL
 ##' for use by \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @usage sit.dat  # phrLoadDatabaseString(sit.dat)
 ##' @keywords dataset 
@@ -977,7 +977,7 @@ NULL
 ##' \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @usage iso.dat  # phrLoadDatabaseString(iso.dat)
 ##' @keywords dataset 
@@ -994,7 +994,7 @@ NULL
 ##' run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' 
@@ -1009,7 +1009,7 @@ NULL
 ##' can be run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' 
@@ -1035,7 +1035,7 @@ NULL
 ##' routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL
@@ -1060,7 +1060,7 @@ NULL
 ##' can be run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL
@@ -1080,7 +1080,7 @@ NULL
 ##' run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL
@@ -1099,7 +1099,7 @@ NULL
 ##' \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL
@@ -1127,7 +1127,7 @@ NULL
 ##' \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL
@@ -1145,7 +1145,7 @@ NULL
 ##' \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL
@@ -1173,7 +1173,7 @@ NULL
 ##' using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL
@@ -1194,7 +1194,7 @@ NULL
 ##' The example can be run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL
@@ -1214,7 +1214,7 @@ NULL
 ##' mixing. The example can be run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL
@@ -1242,7 +1242,7 @@ NULL
 ##' The example can be run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL
@@ -1265,7 +1265,7 @@ NULL
 ##' The example can be run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL
@@ -1291,7 +1291,7 @@ NULL
 ##' \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL
@@ -1314,7 +1314,7 @@ NULL
 ##' \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL
@@ -1339,7 +1339,7 @@ NULL
 ##' \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL
@@ -1364,7 +1364,7 @@ NULL
 ##' example can be run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL
@@ -1399,7 +1399,7 @@ NULL
 ##' \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL
@@ -1420,7 +1420,7 @@ NULL
 ##' can be run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL
@@ -1449,7 +1449,7 @@ NULL
 ##' run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL
@@ -1474,7 +1474,7 @@ NULL
 ##' The example can be run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL
@@ -1497,7 +1497,7 @@ NULL
 ##' \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 NULL

--- a/R/phreeqc.R.in
+++ b/R/phreeqc.R.in
@@ -1248,7 +1248,7 @@ function(value) {
 
 ##' Retrieve the name of the selected_output file.
 ##' 
-##' Retrieves the name of the selected_output file. The default value is selected_{nuser}.0.out.
+##' Retrieves the name of the selected_output file. The default value is selected_\{nuser\}.0.out.
 ##'
 ##' The selected_output file must be turned on using the \code{\link{phrSetSelectedOutputFileOn}} function.
 ##' 
@@ -1291,7 +1291,7 @@ function(nuser) {
 
 ##' Set the name of the selected_output file.
 ##' 
-##' Sets the name of the selected_output file. The default value is selected_{nuser}.0.out.
+##' Sets the name of the selected_output file. The default value is selected_\{nuser\}.0.out.
 ##'
 ##' The selected_output file must be turned on using the \code{\link{phrSetSelectedOutputFileOn}} function.
 ##' 

--- a/R/phreeqc.R.in
+++ b/R/phreeqc.R.in
@@ -1385,7 +1385,7 @@ function(nuser, value) {
 ##' \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @usage phreeqc.dat  # phrLoadDatabaseString(phreeqc.dat)
 ##' @keywords dataset
@@ -1400,7 +1400,7 @@ NULL
 ##' \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @usage ex15.dat  # phrLoadDatabaseString(ex15.dat)
 ##' @keywords dataset
@@ -1416,7 +1416,7 @@ NULL
 ##' reformatted for use by \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @usage Amm.dat  # phrLoadDatabaseString(Amm.dat)
 ##' @keywords dataset
@@ -1490,7 +1490,7 @@ NULL
 ##' has been reformatted for use by \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @usage wateq4f.dat  # phrLoadDatabaseString(wateq4f.dat)
 ##' @keywords dataset
@@ -1506,7 +1506,7 @@ NULL
 ##' for use by \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @usage llnl.dat  # phrLoadDatabaseString(llnl.dat)
 ##' @keywords dataset
 NULL
@@ -1520,7 +1520,7 @@ NULL
 ##' \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @usage minteq.dat  # phrLoadDatabaseString(minteq.dat)
 ##' @keywords dataset
@@ -1535,7 +1535,7 @@ NULL
 ##' \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @usage minteq.v4.dat  # phrLoadDatabaseString(minteq.v4.dat)
 ##' @keywords dataset
@@ -1550,7 +1550,7 @@ NULL
 ##' use by \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @usage pitzer.dat  # phrLoadDatabaseString(pitzer.dat)
 ##' @keywords dataset
@@ -1566,7 +1566,7 @@ NULL
 ##' for use by \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @usage sit.dat  # phrLoadDatabaseString(sit.dat)
 ##' @keywords dataset
@@ -1582,7 +1582,7 @@ NULL
 ##' \code{\link{phrLoadDatabaseString}}.
 ##' @docType data
 ##' @family Databases
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @usage iso.dat  # phrLoadDatabaseString(iso.dat)
 ##' @keywords dataset
@@ -1599,7 +1599,7 @@ NULL
 ##' run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -1620,7 +1620,7 @@ NULL
 ##' can be run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -1652,7 +1652,7 @@ NULL
 ##' routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -1684,7 +1684,7 @@ NULL
 ##' can be run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -1711,7 +1711,7 @@ NULL
 ##' run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -1737,7 +1737,7 @@ NULL
 ##' \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -1772,7 +1772,7 @@ NULL
 ##' \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -1797,7 +1797,7 @@ NULL
 ##' \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -1836,7 +1836,7 @@ NULL
 ##' using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -1864,7 +1864,7 @@ NULL
 ##' The example can be run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -1891,7 +1891,7 @@ NULL
 ##' mixing. The example can be run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -1926,7 +1926,7 @@ NULL
 ##' The example can be run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -1956,7 +1956,7 @@ NULL
 ##' The example can be run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -1989,7 +1989,7 @@ NULL
 ##' \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -2019,7 +2019,7 @@ NULL
 ##' \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -2052,7 +2052,7 @@ NULL
 ##' \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -2084,7 +2084,7 @@ NULL
 ##' example can be run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -2126,7 +2126,7 @@ NULL
 ##' \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -2154,7 +2154,7 @@ NULL
 ##' can be run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -2190,7 +2190,7 @@ NULL
 ##' run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -2222,7 +2222,7 @@ NULL
 ##' The example can be run using the \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples
@@ -2255,7 +2255,7 @@ NULL
 ##' \code{\link{phrRunString}} routine.
 ##' @docType data
 ##' @family Examples
-##' @references \url{http://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
+##' @references \url{https://pubs.usgs.gov/tm/06/a43/pdf/tm6-A43.pdf}
 ##' @source \url{http://wwwbrr.cr.usgs.gov/projects/GWC_coupled/phreeqc}
 ##' @keywords dataset 
 ##' @examples


### PR DESCRIPTION
* Fixed 'format string is not a string literal (potentially insecure) [-Wformat-security]' warnings
* Fixed 'Lost braces; missing escapes or markup?' notes in Roxygen documentation
* Updated tm6-A43.pdf links in Roxygen documentation