### PR TITLE
Add missing include of stddef.h in IPhreeqc.h when IPHREEQC_NO_FORTRAN_MODULE is defined

### DIFF
--- a/src/IPhreeqc.h
+++ b/src/IPhreeqc.h
@@ -6,6 +6,10 @@
 
 #include "Var.h"
 
+#ifdef IPHREEQC_NO_FORTRAN_MODULE
+#include <stddef.h>
+#endif
+
 /**
  * @mainpage IPhreeqc Library Documentation (@PHREEQC_VER@-@REVISION_SVN@)
  *


### PR DESCRIPTION
When `IPHREEQC_NO_FORTRAN_MODULE` is defined, the type of the last parameter of `SetBasicFortranCallback()` function is `size_t`, which is defined in `stddef.h`.

Without this fix, `IPhreeqc.h` is not self sufficient when `IPHREEQC_NO_FORTRAN_MODULE` is defined, leading to compilation error when it's included in a project.