### PR TITLE
Fix typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (STANDALONE_BUILD)
   endif()
 endif()
 
-# overide docdir on windows
+# override docdir on windows
 if (WIN32 AND NOT CMAKE_INSTALL_DOCDIR)
   set(CMAKE_INSTALL_DOCDIR "" CACHE PATH "documentation root (doc)")
   set(CMAKE_INSTALL_DOCDIR "doc")

--- a/IPhreeqc.makefile
+++ b/IPhreeqc.makefile
@@ -42,7 +42,7 @@ ReleaseDll_Preprocessor_Definitions=-D NDEBUG -D GCC_BUILD -D _LIB
 Release_Preprocessor_Definitions=-D NDEBUG -D GCC_BUILD -D _LIB 
 Release_Preprocessor_Definitions=-D NDEBUG -D GCC_BUILD -D _LIB 
 
-# Implictly linked object files...
+# Implicitly linked object files...
 DebugDll_Implicitly_Linked_Objects=
 DebugDll_Implicitly_Linked_Objects=
 Debug_Implicitly_Linked_Objects=

--- a/R/Makefile
+++ b/R/Makefile
@@ -885,7 +885,7 @@ $(IDEST):
 $(DEST):
 	mkdir $(DEST)
 
-# Force directory creation everytime make is executed
+# Force directory creation every time make is executed
 # see https://www.cmcrossroads.com/article/making-directories-gnu-make
 
 $(shell mkdir -p $(TOPDIR)/R)

--- a/R/phreeqc.R.in
+++ b/R/phreeqc.R.in
@@ -32,7 +32,7 @@
 ##' # plot the results
 ##' attach(so$n1)
 ##' title  <- "Gypsum-Anhydrite Stability"
-##' xlabel <- "Temperature, in degrees celcius"
+##' xlabel <- "Temperature, in degrees celsius"
 ##' ylabel <- "Saturation index"
 ##' plot(temp.C., si_gypsum, main = title, xlab = xlabel, ylab = ylabel,
 ##'      col = "darkred", xlim = c(25, 75), ylim = c(-0.4, 0.0))

--- a/R/valgrind.R
+++ b/R/valgrind.R
@@ -1606,7 +1606,7 @@ so <- phrGetSelectedOutput()
 # plot the results
 attach(so$n1)
 title  <- "Gypsum-Anhydrite Stability"
-xlabel <- "Temperature, in degrees celcius"
+xlabel <- "Temperature, in degrees celsius"
 ylabel <- "Saturation index"
 plot(temp.C., si_gypsum, main = title, xlab = xlabel, ylab = ylabel,
      col = "darkred", xlim = c(25, 75), ylim = c(-0.4, 0.0))

--- a/build/dist.sh
+++ b/build/dist.sh
@@ -17,7 +17,7 @@
 #   from the top-level of a branches/0.24.2 working copy will create
 #   the 0.24.2 release tarball.
 #
-#   When building a alpha, beta or rc tarballs pass the apppropriate flag
+#   When building a alpha, beta or rc tarballs pass the appropriate flag
 #   followed by the number for that release.  For example you'd do
 #   the following for a Beta 1 release:
 #      ./dist.sh -v 1.1.0 -r 10277 -pr branches/1.1.x -beta 1

--- a/database/OtherDatabases/CEMDATA18-31-03-2022-phaseVol.dat
+++ b/database/OtherDatabases/CEMDATA18-31-03-2022-phaseVol.dat
@@ -24,7 +24,7 @@ SOLUTION_MASTER_SPECIES
 
 
 #
-#  elemen     species	alk   gfw_formula element_gfw atomic number
+# element     species	alk   gfw_formula element_gfw atomic number
 #
 
 

--- a/database/OtherDatabases/CEMDATA18.1-16-01-2019-phaseVol.dat
+++ b/database/OtherDatabases/CEMDATA18.1-16-01-2019-phaseVol.dat
@@ -22,7 +22,7 @@ SOLUTION_MASTER_SPECIES
 
 
 #
-#  elemen     species	alk   gfw_formula element_gfw atomic number
+# element     species	alk   gfw_formula element_gfw atomic number
 #
 
 

--- a/database/OtherDatabases/CEMDATA18.dat
+++ b/database/OtherDatabases/CEMDATA18.dat
@@ -18,7 +18,7 @@ SOLUTION_MASTER_SPECIES
 
 
 #
-#  elemen     species	alk   gfw_formula element_gfw atomic number
+# element     species	alk   gfw_formula element_gfw atomic number
 #
 
 

--- a/database/OtherDatabases/PSINA_12_07_110615_DAV_s_win.dat
+++ b/database/OtherDatabases/PSINA_12_07_110615_DAV_s_win.dat
@@ -61,7 +61,7 @@ SOLUTION_MASTER_SPECIES
 #                                                                                                      
 #                                                                                                      
 #
-#  elemen     species        alk   gfw_formula element_gfw atomic Disposition           Source of data 
+# element     species        alk   gfw_formula element_gfw atomic Disposition           Source of data
 #                                                          number   PMATCHC    
 #
 H               H+          -1.0        H         1.008   #   1       Ele              NAGRA NTB 91-17   

--- a/examples/com/python/parallel_advect.py
+++ b/examples/com/python/parallel_advect.py
@@ -214,7 +214,7 @@ class ReactionModel(object):
 class PhreeqcCalculator(object):
     """All PHREEQC calculations happen here.
 
-    This is the only place where we interact wit IPhreeqc.
+    This is the only place where we interact with IPhreeqc.
     Each instance of this class might run in a different
     process using `multiprocessing`.
     """

--- a/gtest/TestIPhreeqc.cpp
+++ b/gtest/TestIPhreeqc.cpp
@@ -283,7 +283,7 @@ TEST(TestIPhreeqc, TestSetErrorOn)
 	ASSERT_EQ(false, ::FileExists("missing.file"));
 
 	IPhreeqc obj;
-	ASSERT_EQ(true, obj.GetErrorOn());			// intial setting is true
+	ASSERT_EQ(true, obj.GetErrorOn());			// initial setting is true
 
 	obj.SetErrorOn(false);
 	ASSERT_EQ(false, obj.GetErrorOn());
@@ -314,7 +314,7 @@ TEST(TestIPhreeqc, TestSetErrorOn2)
 	obj.SetErrorFileOn(true);
 	obj.SetErrorFileName(ERR_FILENAME);
 
-	ASSERT_EQ(true, obj.GetErrorOn());			// intial setting is true
+	ASSERT_EQ(true, obj.GetErrorOn());			// initial setting is true
 
 	obj.SetErrorOn(false);
 	ASSERT_EQ(false, obj.GetErrorOn());
@@ -3829,7 +3829,7 @@ TEST(TestIPhreeqc, TestCErrorReporter)
 TEST(TestIPhreeqc, TestDelete)
 {
 	const char input[] =
-		"SOLUTION 1 # definition of intial condition 1\n"
+		"SOLUTION 1 # definition of initial condition 1\n"
 		"COPY cell 1 7405 # copy cell 1 to placeholder cell with index larger than the number of cells in the model domain\n"
 		"END\n"
 		"DELETE # delete initial condition 1 to allow for a redefinition of all reactions\n"

--- a/gtest/TestIPhreeqcLib.cpp
+++ b/gtest/TestIPhreeqcLib.cpp
@@ -190,7 +190,7 @@ TEST(TestIPhreeqcLib, TestSetErrorOn)
 	int n = ::CreateIPhreeqc();
 	ASSERT_TRUE(n >= 0);
 
-	ASSERT_EQ(1, ::GetErrorOn(n));			// intial setting is true
+	ASSERT_EQ(1, ::GetErrorOn(n));			// initial setting is true
 	ASSERT_EQ(IPQ_OK, ::SetErrorOn(n, 0));
 	ASSERT_EQ(0, ::GetErrorOn(n));
 
@@ -4005,7 +4005,7 @@ TEST(TestIPhreeqcLib, TestIEEE)
 TEST(TestIPhreeqcLib, TestDelete)
 {
 	const char input[] =
-		"SOLUTION 1 # definition of intial condition 1\n"
+		"SOLUTION 1 # definition of initial condition 1\n"
 		"COPY cell 1 7405 # copy cell 1 to placeholder cell with index larger than the number of cells in the model domain\n"
 		"END\n"
 		"DELETE # delete initial condition 1 to allow for a redefinition of all reactions\n"

--- a/jenkins-dist.sh
+++ b/jenkins-dist.sh
@@ -17,7 +17,7 @@
 #   from the top-level of a branches/0.24.2 working copy will create
 #   the 0.24.2 release tarball.
 #
-#   When building a alpha, beta or rc tarballs pass the apppropriate flag
+#   When building a alpha, beta or rc tarballs pass the appropriate flag
 #   followed by the number for that release.  For example you'd do
 #   the following for a Beta 1 release:
 #      ./dist.sh -v 1.1.0 -r 10277 -pr branches/1.1.x -beta 1

--- a/packages/dist.sh
+++ b/packages/dist.sh
@@ -17,7 +17,7 @@
 #   from the top-level of a branches/0.24.2 working copy will create
 #   the 0.24.2 release tarball.
 #
-#   When building a alpha, beta or rc tarballs pass the apppropriate flag
+#   When building a alpha, beta or rc tarballs pass the appropriate flag
 #   followed by the number for that release.  For example you'd do
 #   the following for a Beta 1 release:
 #      ./dist.sh -v 1.1.0 -r 10277 -pr branches/1.1.x -beta 1

--- a/src/CSelectedOutput.cpp
+++ b/src/CSelectedOutput.cpp
@@ -247,8 +247,8 @@ std::ostream& operator<< (std::ostream &os, const CSelectedOutput &a)
 void CSelectedOutput::Serialize(
 	int row_number,
 	std::vector<int> &types,        // each column for each row types, including headings
-	std::vector<long> &longs,       // in order by occurance
-	std::vector<double> &doubles,   // in order by occurance
+	std::vector<long> &longs,       // in order by occurrence
+	std::vector<double> &doubles,   // in order by occurrence
 	std::string &strings)
 {
 	types.clear();
@@ -300,8 +300,8 @@ void CSelectedOutput::Serialize(
 }
 void CSelectedOutput::DeSerialize(
 	std::vector<int> &types,        // each column for each row types, including headings
-	std::vector<long> &longs,       // in order by occurance
-	std::vector<double> &doubles,   // in order by occurance
+	std::vector<long> &longs,       // in order by occurrence
+	std::vector<double> &doubles,   // in order by occurrence
 	std::string &strings)
 {
 	size_t i_types = 0, i_longs = 0, i_doubles = 0;

--- a/src/IPhreeqc.cpp
+++ b/src/IPhreeqc.cpp
@@ -110,7 +110,7 @@ VRESULT IPhreeqc::AccumulateLine(const char *line)
 	}
 	catch (...)
 	{
-		this->AddError("AccumulateLine: An unhandled exception occured.\n");
+		this->AddError("AccumulateLine: An unhandled exception occurred.\n");
 		throw;
 	}
 	return VR_OUTOFMEMORY;
@@ -607,7 +607,7 @@ int IPhreeqc::load_db(const char* filename)
 	}
 	catch (...)
 	{
-		const char *errmsg = "LoadDatabase: An unhandled exception occured.\n";
+		const char *errmsg = "LoadDatabase: An unhandled exception occurred.\n";
 		try
 		{
 			this->PhreeqcPtr->error_msg(errmsg, STOP); // throws IPhreeqcStop
@@ -670,7 +670,7 @@ int IPhreeqc::load_db_str(const char* input)
 	}
 	catch(...)
 	{
-		const char *errmsg = "LoadDatabaseString: An unhandled exception occured.\n";
+		const char *errmsg = "LoadDatabaseString: An unhandled exception occurred.\n";
 		try
 		{
 			this->PhreeqcPtr->error_msg(errmsg, STOP); // throws PhreeqcStop
@@ -773,7 +773,7 @@ int IPhreeqc::RunAccumulated(void)
 	}
 	catch(...)
 	{
-		const char *errmsg = "RunAccumulated: An unhandled exception occured.\n";
+		const char *errmsg = "RunAccumulated: An unhandled exception occurred.\n";
 		try
 		{
 			this->PhreeqcPtr->error_msg(errmsg, STOP); // throws PhreeqcStop
@@ -844,7 +844,7 @@ int IPhreeqc::RunFile(const char* filename)
 	}
 	catch(...)
 	{
-		const char *errmsg = "RunFile: An unhandled exception occured.\n";
+		const char *errmsg = "RunFile: An unhandled exception occurred.\n";
 		try
 		{
 			this->PhreeqcPtr->error_msg(errmsg, STOP); // throws PhreeqcStop
@@ -907,7 +907,7 @@ int IPhreeqc::RunString(const char* input)
 	}
 	catch(...)
 	{
-		const char *errmsg = "RunString: An unhandled exception occured.\n";
+		const char *errmsg = "RunString: An unhandled exception occurred.\n";
 		try
 		{
 			this->PhreeqcPtr->error_msg(errmsg, STOP); // throws PhreeqcStop
@@ -1285,7 +1285,7 @@ void IPhreeqc::do_run(const char* sz_routine, std::istream* pis, PFN_PRERUN_CALL
 			// (punch.in == TRUE) when any "RUN" has contained
 			// a SELECTED_OUTPUT block since the last LoadDatabase call.
 			//
-			// Since LoadDatabase inititializes punch.in to FALSE
+			// Since LoadDatabase initializes punch.in to FALSE
 			// (via UnLoadDatabase...do_initialize)
 			// and punch.in is set to TRUE in read_selected_output
 			//

--- a/src/IPhreeqc.h
+++ b/src/IPhreeqc.h
@@ -73,7 +73,7 @@ extern "C" {
  *  Internally used to create an error condition.
  *  @param id            The instance id returned from @ref CreateIPhreeqc.
  *  @param error_msg     The error message to display.
- *  @return              The current error count if successful; otherwise a negative value indicates an error occured (see @ref IPQ_RESULT).
+ *  @return              The current error count if successful; otherwise a negative value indicates an error occurred (see @ref IPQ_RESULT).
  *  @see                 GetErrorString, GetErrorStringLine, GetErrorStringLineCount, OutputErrorString
  *  @par Fortran90 Interface:
  *  @htmlonly
@@ -96,7 +96,7 @@ extern "C" {
  *  Internally used to create a warning condition.
  *  @param id            The instance id returned from @ref CreateIPhreeqc.
  *  @param warn_msg      The warning message to display.
- *  @return              The current warning count if successful; otherwise a negative value indicates an error occured (see @ref IPQ_RESULT).
+ *  @return              The current warning count if successful; otherwise a negative value indicates an error occurred (see @ref IPQ_RESULT).
  *  @see                 GetWarningString, GetWarningStringLine, GetWarningStringLineCount, OutputWarningString
  *  @par Fortran90 Interface:
  *  @htmlonly
@@ -137,7 +137,7 @@ extern "C" {
 
 /**
  *  Create a new IPhreeqc instance.
- *  @return      A non-negative value if successful; otherwise a negative value indicates an error occured (see @ref IPQ_RESULT).
+ *  @return      A non-negative value if successful; otherwise a negative value indicates an error occurred (see @ref IPQ_RESULT).
  *  @see         DestroyIPhreeqc
  *  @par Fortran90 Interface:
  *  @htmlonly
@@ -224,7 +224,7 @@ extern "C" {
  *  Retrieves the number of components in the current component list.
  *  @param id            The instance id returned from @ref CreateIPhreeqc.
  *  @return              The current count of components.
- *                       A negative value indicates an error occured (see @ref IPQ_RESULT).
+ *                       A negative value indicates an error occurred (see @ref IPQ_RESULT).
  *  @see                 GetComponent
  *  @par Fortran90 Interface:
  *  @htmlonly
@@ -671,7 +671,7 @@ extern "C" {
  *  Retrieves the nth user number of the currently defined <B>SELECTED_OUTPUT</B> keyword blocks.
  *  @param id            The instance id returned from @ref CreateIPhreeqc.
  *  @param n             The zero-based index of the <B>SELECTED_OUTPUT</B> user number to retrieve.
- *  @return              The nth defined user number; a negative value indicates an error occured.
+ *  @return              The nth defined user number; a negative value indicates an error occurred.
  *  @see                 GetCurrentSelectedOutputUserNumber, GetSelectedOutputCount, SetCurrentSelectedOutputUserNumber
  *  @pre @ref RunAccumulated, @ref RunFile, @ref RunString must have been called and returned 0 (zero) errors.
  *  @par Fortran90 Interface:

--- a/src/IPhreeqc.hpp
+++ b/src/IPhreeqc.hpp
@@ -25,7 +25,7 @@ class SelectedOutput;
  * @class IPhreeqcStop
  *
  * @brief This class is derived from std::exception and is thrown
- * when an unrecoverable error has occured.
+ * when an unrecoverable error has occurred.
  */
 class IPQ_DLL_EXPORT IPhreeqcStop : public std::exception 
 {
@@ -289,7 +289,7 @@ public:
 	/**
 	 *  Retrieves the nth user number of the currently defined <B>SELECTED_OUTPUT</B> blocks.
 	 *  @param n                The zero-based index of the <B>SELECTED_OUTPUT</B> user number to retrieve.
-	 *  @return                 The nth defined user number; a negative value indicates an error occured.
+	 *  @return                 The nth defined user number; a negative value indicates an error occurred.
 	 *  @see                    GetCurrentSelectedOutputUserNumber, GetSelectedOutputCount, SetCurrentSelectedOutputUserNumber
 	 */
 	int                      GetNthSelectedOutputUserNumber(int n)const;

--- a/test_ieee/cdmusic_hiemstra.dat
+++ b/test_ieee/cdmusic_hiemstra.dat
@@ -347,7 +347,7 @@ SURFACE_SPECIES
 
       Fhy_triOH0.5  = Fhy_triO-0.5 + 0.5H+
            -cd_music  -0.5 0 0 0 0
-           log_k 10                  # make neglible
+           log_k 10                  # make negligible
 
         Fhy_triO-0.5 + H+ = Fhy_triOH+0.5
              -cd_music  1 0 0 0 0
@@ -427,7 +427,7 @@ SURFACE_SPECIES
 
       Fhy_unicOH1.5 = Fhy_unicOH-0.5 + 0.5H+
              -cd_music  -0.5 0 0 0 0
-             log_k 10                  # make neglible
+             log_k 10                  # make negligible
 
         Fhy_unicOH-0.5 + H+ = Fhy_unicOH2+0.5
              -cd_music  1 0 0 0 0

--- a/unit/TestIPhreeqc.cpp
+++ b/unit/TestIPhreeqc.cpp
@@ -3592,7 +3592,7 @@ void TestIPhreeqc::TestCErrorReporter(void)
 void TestIPhreeqc::TestDelete(void)
 {
 	const char input[] =
-		"SOLUTION 1 # definition of intial condition 1\n"
+		"SOLUTION 1 # definition of initial condition 1\n"
 		"COPY cell 1 7405 # copy cell 1 to placeholder cell with index larger than the number of cells in the model domain\n"
 		"END\n"
 		"DELETE # delete initial condition 1 to allow for a redefinition of all reactions\n"

--- a/unit/TestIPhreeqcLib.cpp
+++ b/unit/TestIPhreeqcLib.cpp
@@ -3971,7 +3971,7 @@ void TestIPhreeqcLib::TestIEEE(void)
 void TestIPhreeqcLib::TestDelete(void)
 {
 	const char input[] =
-		"SOLUTION 1 # definition of intial condition 1\n"
+		"SOLUTION 1 # definition of initial condition 1\n"
 		"COPY cell 1 7405 # copy cell 1 to placeholder cell with index larger than the number of cells in the model domain\n"
 		"END\n"
 		"DELETE # delete initial condition 1 to allow for a redefinition of all reactions\n"


### PR DESCRIPTION
Similar to https://github.com/usgs-coupled/phreeqc3/pull/74 this PR fixes a few typos, found using codespell.

- Some are identified in user-visible messages and in R graphics
- One common typo found in a few database files
- The majority are found in comments, some of which are used in doxygen docs